### PR TITLE
per-task retry option

### DIFF
--- a/dagger/__init__.py
+++ b/dagger/__init__.py
@@ -1,2 +1,2 @@
-from run import DaggerException, run_tasks
-from task import Task
+from .run import DaggerException, run_tasks
+from .task import Task

--- a/dagger/task.py
+++ b/dagger/task.py
@@ -6,13 +6,18 @@ class Task(object):
     leads to undefined behavior.
     """
 
-    def __init__(self, config, dependencies=[]):
+    # default number of retries that subclasses can set for their failure mitigation
+    DEFAULT_RETRIES = 0
+
+    def __init__(self, config, dependencies=[], retries=None):
         """
         :param config: Picklable data that defines this task's behavior
         :param dependencies: List of tasks that this task depends on
+        :param retries: The number of times the task should be retried on failure
         """
         self.config = config
         self.dependencies = dependencies
+        self.retries_on_failure = self.DEFAULT_RETRIES if retries is None else retries
 
     def __str__(self):
         return "{0}".format(

--- a/tests/test_failure.py
+++ b/tests/test_failure.py
@@ -1,15 +1,29 @@
 import time
+from multiprocessing import Value as SharedMemoryValue
 
 import pytest
 
 from dagger import DaggerException, run_tasks, Task
 
 
+# Share failure counter between processes to correctly count down the failed attempts.
+# Need to create it globally in order to inherit it into child processes.
+failure_counter = SharedMemoryValue("i", 0, lock=False)
+
+
 class CrawlTask(Task):
 
+    def __init__(self, failures=0, retries=None):
+        if failures:
+            failure_counter.value = failures
+
+        super(CrawlTask, self).__init__(
+            config={'fail_and_retry': failures > 0},
+            retries=retries)
+
     def run(self):
-        if self.config.get("failures", 0) > 0:
-            self.config["failures"] -= 1
+        if self.config['fail_and_retry'] and failure_counter.value > 0:
+            failure_counter.value -= 1
             time.sleep(2)
             None.fail()
         else:
@@ -28,7 +42,7 @@ class UnsafeRetriedCrawlTask(CrawlTask):
         if not self.SANE_STATE:
             raise RuntimeError("unsafe state change detected")
         self.SANE_STATE = False
-        super(UnsafeCrawlTask, self).run()
+        super(UnsafeRetriedCrawlTask, self).run()
 
 
 class ExtractTask(Task):
@@ -39,8 +53,8 @@ class ExtractTask(Task):
 
 def test_failure():
 
-    blessed_crawl = CrawlTask({"failures": 0})
-    doomed_crawl = CrawlTask({"failures": 1})
+    blessed_crawl = CrawlTask(failures=0)
+    doomed_crawl = CrawlTask(failures=1)
 
     extract_1 = ExtractTask({}, [blessed_crawl])
     extract_2 = ExtractTask({}, [doomed_crawl])
@@ -60,27 +74,42 @@ def test_retry_on_failure_with_success():
     """
     Test that retrying leads to success if the last retry succeeds
     """
-    blessed_crawl = CrawlTask({"failures": 0})
-    retried_crawl = CrawlTask({"failures": 3}, retries=3)
+    blessed_crawl = CrawlTask(failures=0)
+    retried_crawl = CrawlTask(failures=3, retries=3)
 
     extract_1 = ExtractTask({}, [blessed_crawl])
     extract_2 = ExtractTask({}, [retried_crawl])
 
+    assert blessed_crawl.retries_on_failure == 0
     assert retried_crawl.retries_on_failure == 3
-    with pytest.raises(DaggerException) as exc_info:
-        run_tasks([extract_1, extract_2])
+    result = run_tasks([extract_1, extract_2])
+    assert blessed_crawl.retries_on_failure == 0
     assert retried_crawl.retries_on_failure == 0
+    assert result
 
-    ex = exc_info.value
-    assert set([retried_crawl]) == ex.failed_tasks
-    assert set([blessed_crawl, extract_1]) == ex.done_tasks
-    assert set([extract_2]) == ex.pending_tasks
+
+def test_retry_on_one_failure_with_success():
+    """
+    Test that retrying leads to success if any retry succeeds
+    """
+    blessed_crawl = CrawlTask(failures=0)
+    retried_crawl = CrawlTask(failures=1, retries=3)
+
+    extract_1 = ExtractTask({}, [blessed_crawl])
+    extract_2 = ExtractTask({}, [retried_crawl])
+
+    assert blessed_crawl.retries_on_failure == 0
+    assert retried_crawl.retries_on_failure == 3
+    result = run_tasks([extract_1, extract_2])
+    assert blessed_crawl.retries_on_failure == 0
+    assert retried_crawl.retries_on_failure == 2
+    assert result
 
 
 def test_retry_on_failure_with_abort():
 
-    blessed_crawl = CrawlTask({"failures": 0})
-    retried_crawl = UnsafeRetriedCrawlTask({"failures": 3})
+    blessed_crawl = CrawlTask(failures=0)
+    retried_crawl = UnsafeRetriedCrawlTask(failures=3)
 
     extract_1 = ExtractTask({}, [blessed_crawl])
     extract_2 = ExtractTask({}, [retried_crawl])

--- a/tests/test_failure.py
+++ b/tests/test_failure.py
@@ -8,11 +8,27 @@ from dagger import DaggerException, run_tasks, Task
 class CrawlTask(Task):
 
     def run(self):
-        if self.config["fail"]:
+        if self.config.get("failures", 0) > 0:
+            self.config["failures"] -= 1
             time.sleep(2)
             None.fail()
         else:
             time.sleep(1)
+
+
+class UnsafeRetriedCrawlTask(CrawlTask):
+    """
+    Used to verify that any changes in the task instance state do not leak
+    into the next execution.
+    """
+    DEFAULT_RETRIES = 2
+    SANE_STATE = True
+
+    def run(self):
+        if not self.SANE_STATE:
+            raise RuntimeError("unsafe state change detected")
+        self.SANE_STATE = False
+        super(UnsafeCrawlTask, self).run()
 
 
 class ExtractTask(Task):
@@ -23,16 +39,58 @@ class ExtractTask(Task):
 
 def test_failure():
 
-    blessed_crawl = CrawlTask({"fail": False})
-    doomed_crawl = CrawlTask({"fail": True})
+    blessed_crawl = CrawlTask({"failures": 0})
+    doomed_crawl = CrawlTask({"failures": 1})
 
     extract_1 = ExtractTask({}, [blessed_crawl])
     extract_2 = ExtractTask({}, [doomed_crawl])
 
+    assert doomed_crawl.retries_on_failure == 0
     with pytest.raises(DaggerException) as exc_info:
         run_tasks([extract_1, extract_2])
+    assert doomed_crawl.retries_on_failure == 0
 
     ex = exc_info.value
     assert set([doomed_crawl]) == ex.failed_tasks
+    assert set([blessed_crawl, extract_1]) == ex.done_tasks
+    assert set([extract_2]) == ex.pending_tasks
+
+
+def test_retry_on_failure_with_success():
+    """
+    Test that retrying leads to success if the last retry succeeds
+    """
+    blessed_crawl = CrawlTask({"failures": 0})
+    retried_crawl = CrawlTask({"failures": 3}, retries=3)
+
+    extract_1 = ExtractTask({}, [blessed_crawl])
+    extract_2 = ExtractTask({}, [retried_crawl])
+
+    assert retried_crawl.retries_on_failure == 3
+    with pytest.raises(DaggerException) as exc_info:
+        run_tasks([extract_1, extract_2])
+    assert retried_crawl.retries_on_failure == 0
+
+    ex = exc_info.value
+    assert set([retried_crawl]) == ex.failed_tasks
+    assert set([blessed_crawl, extract_1]) == ex.done_tasks
+    assert set([extract_2]) == ex.pending_tasks
+
+
+def test_retry_on_failure_with_abort():
+
+    blessed_crawl = CrawlTask({"failures": 0})
+    retried_crawl = UnsafeRetriedCrawlTask({"failures": 3})
+
+    extract_1 = ExtractTask({}, [blessed_crawl])
+    extract_2 = ExtractTask({}, [retried_crawl])
+
+    assert retried_crawl.retries_on_failure == UnsafeRetriedCrawlTask.DEFAULT_RETRIES > 0
+    with pytest.raises(DaggerException) as exc_info:
+        run_tasks([extract_1, extract_2])
+    assert retried_crawl.retries_on_failure == 0
+
+    ex = exc_info.value
+    assert set([retried_crawl]) == ex.failed_tasks
     assert set([blessed_crawl, extract_1]) == ex.done_tasks
     assert set([extract_2]) == ex.pending_tasks


### PR DESCRIPTION
This change adds a retry option at the task level in order to allow idempotent tasks to to be repeated on (temporary) failures.

From the wording in the ticket, it might be that the original intention was to have a per-graph execution option that repeats any of the tasks on failure, but my intuition leans towards preferring a per-task option, as not every task might be safely repeatable. Please advise if this is acceptable. A per-graph option can easily be implemented on top of this change.

Fixes issue #3.