### PR TITLE
Fixes issue#1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,61 @@
+# Created by .ignore support plugin (hsz.mobi)
+### Python template
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+
+# Translations
+*.mo
+*.pot
+
+# Django stuff:
+*.log
+
+# Sphinx documentation
+docs/_build/
+
+# PyBuilder
+target/
+

--- a/dagger/run.py
+++ b/dagger/run.py
@@ -104,8 +104,7 @@ def run_partial_tasks(pending_tasks, done_tasks, pool_size=None, tick=1):
                 done_tasks.add(task)
             else:
                 logging.critical("Failed: %s", task)
-                logging.critical("Waiting for completion of: %d tasks",
-                                 num_tasks - len(pending_tasks) - len(done_tasks) - 1)
+                logging.critical("Waiting for completion of: %d tasks", num_tasks - len(pending_tasks) - len(done_tasks) - 1)
 
                 error_state["success"] = False
                 error_state["failed_tasks"].add(task)

--- a/dagger/run.py
+++ b/dagger/run.py
@@ -45,10 +45,10 @@ class DaggerException(Exception):
             "- done tasks: {num_done}\n"
             "- failed tasks: {failed}"
         ).format(
-            name=type(self).__name__,
-            num_pending=len(self.pending_tasks),
-            num_done=len(self.done_tasks),
-            failed=", ".join(str(task) for task in self.failed_tasks)
+                name=type(self).__name__,
+                num_pending=len(self.pending_tasks),
+                num_done=len(self.done_tasks),
+                failed=", ".join(str(task) for task in self.failed_tasks)
         )
 
 
@@ -67,6 +67,7 @@ def run_tasks(initial_tasks, pool_size=None, tick=1):
 
     pending_tasks = set(initial_tasks)
     for task in initial_tasks:
+        task.thread_safe_check_circular_dependencies([])
         pending_tasks |= set(task.get_all_dependencies())
     done_tasks = set()
 
@@ -103,7 +104,8 @@ def run_partial_tasks(pending_tasks, done_tasks, pool_size=None, tick=1):
                 done_tasks.add(task)
             else:
                 logging.critical("Failed: %s", task)
-                logging.critical("Waiting for completion of: %d tasks", num_tasks - len(pending_tasks) - len(done_tasks) - 1)
+                logging.critical("Waiting for completion of: %d tasks",
+                                 num_tasks - len(pending_tasks) - len(done_tasks) - 1)
 
                 error_state["success"] = False
                 error_state["failed_tasks"].add(task)
@@ -117,12 +119,12 @@ def run_partial_tasks(pending_tasks, done_tasks, pool_size=None, tick=1):
                      len(pending_tasks),
                      num_tasks - len(pending_tasks) - len(done_tasks),
                      len(done_tasks)
-        )
+                     )
 
     while pending_tasks:
         running_tasks = set(
-            task for task in pending_tasks
-            if all(dep in done_tasks for dep in task.dependencies)
+                task for task in pending_tasks
+                if all(dep in done_tasks for dep in task.dependencies)
         )
         for task in running_tasks:
             run_task(task)

--- a/dagger/run.py
+++ b/dagger/run.py
@@ -45,10 +45,10 @@ class DaggerException(Exception):
             "- done tasks: {num_done}\n"
             "- failed tasks: {failed}"
         ).format(
-                name=type(self).__name__,
-                num_pending=len(self.pending_tasks),
-                num_done=len(self.done_tasks),
-                failed=", ".join(str(task) for task in self.failed_tasks)
+            name=type(self).__name__,
+            num_pending=len(self.pending_tasks),
+            num_done=len(self.done_tasks),
+            failed=", ".join(str(task) for task in self.failed_tasks)
         )
 
 
@@ -67,7 +67,7 @@ def run_tasks(initial_tasks, pool_size=None, tick=1):
 
     pending_tasks = set(initial_tasks)
     for task in initial_tasks:
-        task.thread_safe_check_circular_dependencies([])
+        task.check_circular_dependencies([])
         pending_tasks |= set(task.get_all_dependencies())
     done_tasks = set()
 
@@ -119,12 +119,12 @@ def run_partial_tasks(pending_tasks, done_tasks, pool_size=None, tick=1):
                      len(pending_tasks),
                      num_tasks - len(pending_tasks) - len(done_tasks),
                      len(done_tasks)
-                     )
+        )
 
     while pending_tasks:
         running_tasks = set(
-                task for task in pending_tasks
-                if all(dep in done_tasks for dep in task.dependencies)
+            task for task in pending_tasks
+            if all(dep in done_tasks for dep in task.dependencies)
         )
         for task in running_tasks:
             run_task(task)

--- a/dagger/task.py
+++ b/dagger/task.py
@@ -48,6 +48,7 @@ class Task(object):
         in the dependencies resolution.
         It allows different threads to run visit on same object without
         influencing each-other dependencies checks.
+        If no visiting_list is passed it initializes a new one.
 
         :param visiting_list: list the list of already visited Tasks.
         :raises: CircularDependencyException

--- a/dagger/task.py
+++ b/dagger/task.py
@@ -1,3 +1,16 @@
+class CircularDependencyException(Exception):
+    """
+    Circular dependencies error between tasks.
+    """
+
+    def __init__(self, tasks_chain):
+        """
+        :param repeated_tasks: Tasks that has been visited 'till the circular dependency error
+        :return:
+        """
+        self.tasks_chain = tasks_chain
+
+
 class Task(object):
     """
     A unit of work to be run by Dagger. Implement the run() method in a subclass to define concrete tasks.
@@ -13,11 +26,12 @@ class Task(object):
         """
         self.config = config
         self.dependencies = dependencies
+        self.visiting = False
 
     def __str__(self):
         return "{0}".format(
-            type(self).__name__
-            )
+                type(self).__name__
+        )
 
     def get_all_dependencies(self):
         """
@@ -28,6 +42,30 @@ class Task(object):
         for dep in self.dependencies:
             all_deps += dep.get_all_dependencies()
         return all_deps
+
+    def thread_safe_check_circular_dependencies(self, visiting_list):
+        """
+        This method uses a list passed as parameter to check visited elements
+        in the dependencies resolution.
+        It allows different threads to run visit on same object without
+        influencing each-other dependencies checks.
+
+        :param visiting_list: list the list of already visited Tasks.
+        :raises: CircularDependencyException
+        """
+        if self in visiting_list:
+            raise CircularDependencyException(self)
+        else:
+            visiting_list.append(self)
+
+        for dep in self.dependencies:
+            if dep not in visiting_list:
+                dep.thread_safe_check_circular_dependencies(visiting_list)
+            else:
+                visiting_list.append(dep)
+                raise CircularDependencyException(visiting_list)
+
+        visiting_list.remove(self)
 
     def run(self):
         """

--- a/dagger/task.py
+++ b/dagger/task.py
@@ -26,7 +26,6 @@ class Task(object):
         """
         self.config = config
         self.dependencies = dependencies
-        self.visiting = False
 
     def __str__(self):
         return "{0}".format(
@@ -43,7 +42,7 @@ class Task(object):
             all_deps += dep.get_all_dependencies()
         return all_deps
 
-    def thread_safe_check_circular_dependencies(self, visiting_list):
+    def check_circular_dependencies(self, visiting_list=None):
         """
         This method uses a list passed as parameter to check visited elements
         in the dependencies resolution.
@@ -53,6 +52,10 @@ class Task(object):
         :param visiting_list: list the list of already visited Tasks.
         :raises: CircularDependencyException
         """
+
+        if visiting_list is None:
+            visiting_list = []
+
         if self in visiting_list:
             raise CircularDependencyException(self)
         else:
@@ -60,7 +63,7 @@ class Task(object):
 
         for dep in self.dependencies:
             if dep not in visiting_list:
-                dep.thread_safe_check_circular_dependencies(visiting_list)
+                dep.check_circular_dependencies(visiting_list)
             else:
                 visiting_list.append(dep)
                 raise CircularDependencyException(visiting_list)

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,5 @@ setuptools.setup(
         "pytest"
     ],
     cmdclass={"test": PyTest},
-
     platforms="any",
 )

--- a/tests/test_cyclic_dependency.py
+++ b/tests/test_cyclic_dependency.py
@@ -1,0 +1,68 @@
+import pytest
+
+from dagger import Task, DaggerException, run_tasks
+from dagger.task import CircularDependencyException
+
+
+class TaskTest(Task):
+    """
+    Inherited Task class,
+    run method is NotImplemented.
+    """
+
+    def run(self):
+        """
+        :return: None
+        """
+        print("Hello world! I am %s" % self.config["name"])
+
+
+def test_acyclic_dependency():
+    """
+    You have tasks A,B,C,D
+    with the following dependencies.
+
+    A ---> B ---> C
+    A ---> D ---> C
+
+    It should run tasks with no error
+    """
+    C = TaskTest({"name": "C"}, [])
+
+    B = TaskTest({"name": "B"}, [C])
+
+    D = TaskTest({"name": "D"}, [C])
+
+    A = TaskTest({"name": "A"}, [B, D])
+
+    assert run_tasks([A, D]) is True
+
+
+def test_cyclic_dependency():
+    """
+    You have tasks A,B,C
+    with the following dependencies.
+
+    A ---> B ---> C ---> A
+
+    B ---> C
+
+    C
+
+    It should raise CircularDependencyException
+    due to circular dependency on A task.
+    """
+    C = TaskTest({"name": "C"}, [])
+
+    B = TaskTest({"name": "B"}, [C])
+
+    A = TaskTest({"name": "A"}, [B])
+
+    C.dependencies.append(A)
+
+    A.dependencies.append(C)
+
+    with pytest.raises(CircularDependencyException) as exc_info:
+        run_tasks([A, B, C])
+
+    assert exc_info.value.tasks_chain == [A, B, C, A]

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -23,7 +23,6 @@ class IncTask(Task):
     """
     Increment a value in the shared array.
     """
-
     def run(self):
         array[self.config["index"]] += 1
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -23,6 +23,7 @@ class IncTask(Task):
     """
     Increment a value in the shared array.
     """
+
     def run(self):
         array[self.config["index"]] += 1
 


### PR DESCRIPTION
When a cyclic dependency is detected method run_tasks raises a CircularDependencyException and prevents tasks execution.

Added a couple of things on test.py:
-  Method thread_safe_check_circular_dependencies to recursively check dependencies starting from a certain task
-  CircularDependencyException class to raise an error when circular dependencies happen

Modified run.py:
-  Added the thread_safe_check_circular_dependencies step before calculating dependencies

Added test_cyclic_dependency.py:
-  One test that doesn't causes CircularDependencyException (diamond configuration)
-  One test that causes CircularDependencyException


Also added a .gitignore file generated with PyCharm